### PR TITLE
fix/spl_php8_type_error

### DIFF
--- a/autoload_aliases.php
+++ b/autoload_aliases.php
@@ -6,4 +6,4 @@ function autoload_propel_aliases($className) {
     }
 }
 
-spl_autoload_register('autoload_propel_aliases', false, true);
+spl_autoload_register('autoload_propel_aliases', true, true);


### PR DESCRIPTION
Fixes warning:
> PHP Notice:  spl_autoload_register(): Argument #2 ($do_throw) has been ignored, spl_autoload_register() will always throw in /home/runner/work/bsn-playerpayment/bsn-playerpayment/symfony/vendor/dayspring-tech/propel-bundle/autoload_aliases.php on line 9

Also unblocks PHPStorm from running PHPUnit tests via IDE

https://www.php.net/manual/en/function.spl-autoload-register.php#126119