### PR TITLE
fix propel path

### DIFF
--- a/DependencyInjection/PropelExtension.php
+++ b/DependencyInjection/PropelExtension.php
@@ -35,7 +35,7 @@ class PropelExtension extends Extension
         $config = $processor->processConfiguration($configuration, $configs);
 
         // Composer
-        if (file_exists($propelPath = $container->getParameter('kernel.root_dir') . '/../vendor/propel/propel1')) {
+        if (file_exists($propelPath = $container->getParameter('kernel.root_dir') . '/../vendor/dayspring-tech/propel1')) {
             $container->setParameter('propel.path', $propelPath);
         }
         if (file_exists($phingPath = $container->getParameter('kernel.root_dir') . '/../vendor/phing/phing/classes')) {


### PR DESCRIPTION
Thanks for maintenance this bundle. Just try to switch to your repo, but i had this exception

`
PropelBundle expects a "path" parameter that must contain the absolute path  
   to the Propel ORM vendor library. The "path" parameter must be defined und  
  er the "propel" root node in your configuration.
`

This PR fixes this issue.